### PR TITLE
Add alias for run-script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ $ source aliases.sh
 | `ni`  | `npm install` |
 | `nis` | `npm install --save` |
 | `nid` | `npm install --save-dev` |
+| `nr`  | `npm run-script` |
 
 ## License
 

--- a/aliases.sh
+++ b/aliases.sh
@@ -1,3 +1,4 @@
 alias ni="npm install"
 alias nis="npm install --save"
 alias nid="npm install --save-dev"
+alias nr="npm run-script"


### PR DESCRIPTION
Very useful for non-standard npm scripts, e.g., I often use `nr build`.
